### PR TITLE
Fix DateTime display for locales with era format code

### DIFF
--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -334,7 +334,14 @@ namespace ExcelNumberFormat
                             }
 
                             // Reset the culture's calendar
-                            culture.DateTimeFormat.Calendar = nonGregorianCalendar;
+                            try
+                            {
+                                culture.DateTimeFormat.Calendar = nonGregorianCalendar;
+                            }
+                            catch (InvalidOperationException)
+                            {
+                                // Failed to reset the culture's calendar
+                            }
                         }
                     }
 

--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -416,6 +416,7 @@ namespace ExcelNumberFormat
                     string gToken = string.Empty;
                     try
                     {
+                        
                         gToken = tokens[tokenIndex + 1];
                     }
                     catch (Exception)
@@ -429,7 +430,19 @@ namespace ExcelNumberFormat
                     }
                     if (!isNextTokenG)
                     {
-                        FormatLiteral(token, result);
+                        if (token.Contains("\""))
+                        {
+                            token = token.Replace("\"", string.Empty);
+                        }
+                        if (int.TryParse(token, out _))
+                        {
+                            // Skip output of locale ID
+                            // TODO: what if the token is an integer but it's not a locale ID?
+                        }
+                        else
+                        {
+                            FormatLiteral(token, result);
+                        }
                     }
                 }
             }

--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -241,9 +241,120 @@ namespace ExcelNumberFormat
                 }
                 else if (token.StartsWith("g", StringComparison.OrdinalIgnoreCase))
                 {
+                    // If culture contains calendar that contains era, use that
+                    if (tokens.Contains("e"))
+                    {
+                        if (culture == CultureInfo.InvariantCulture)
+                        {
+                            try
+                            {
+                                int tokenIndex = tokens.IndexOf(token);
+                                string localeId = tokens[tokenIndex - 1];
+                                if (!string.IsNullOrEmpty(localeId))
+                                {
+                                    localeId = localeId.Trim('\"');
+                                }
+                                if (int.TryParse(localeId, NumberStyles.HexNumber, culture, out int lcid))
+                                {
+                                    // .NET Standard 1.0 does not support creating CultureInfo from a LCID,
+                                    // so we find one from a custom dictionary. Here we support only:
+                                    //  Japanese, Chinese Traditional (Taiwan)
+                                    Dictionary<int, string> dictCultureInfo = new Dictionary<int, string>()
+                                    {
+                                        { 1041, "ja-JP" },
+                                        { 1028, "zh-TW" }
+                                    };
+                                    if (dictCultureInfo.TryGetValue(lcid, out string locale))
+                                    {
+                                        culture = new CultureInfo(locale);
+                                        if (culture.Name.StartsWith("ja", StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            Calendar japaneseCalendar = null;
+                                            foreach (var calendar in culture.OptionalCalendars)
+                                            {
+                                                if (calendar.GetType() == CultureInfo.InvariantCulture.Calendar.GetType())
+                                                {
+                                                    continue;
+                                                }
+                                                japaneseCalendar = calendar;
+                                                break;
+                                            }
+                                            if (japaneseCalendar != null)
+                                            {
+                                                culture.DateTimeFormat.Calendar = japaneseCalendar;
+                                            }
+                                            //era = culture.DateTimeFormat.Calendar.GetEra(date.AdjustedDateTime);
+                                            //eraName = GetJapaneseEraEnglishAbbreviation(culture, era);
+                                        }
+                                        else if (string.Equals(culture.Name, "zh-TW", StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            Calendar taiwanCalendar = null;
+                                            foreach (var calendar in culture.OptionalCalendars)
+                                            {
+                                                if (calendar.GetType() == CultureInfo.InvariantCulture.Calendar.GetType())
+                                                {
+                                                    continue;
+                                                }
+                                                taiwanCalendar = calendar;
+                                                break;
+                                            }
+                                            if (taiwanCalendar != null)
+                                            {
+                                                culture.DateTimeFormat.Calendar = taiwanCalendar;
+                                            }
+                                            //eraName = culture.DateTimeFormat.GetAbbreviatedEraName(era);
+                                        }
+                                    }
+                                }
+                            }
+                            catch (Exception)
+                            {
+
+                            }
+                        }
+                        else
+                        {
+                            // Get calendars that are not Gregorian
+                            var nonGregorianCalendars = new List<Calendar>();
+                            foreach (var calendar in culture.OptionalCalendars)
+                            {
+                                if (calendar.GetType() == CultureInfo.InvariantCulture.Calendar.GetType())
+                                {
+                                    continue;
+                                }
+                                nonGregorianCalendars.Add(calendar);
+                            }
+
+                            // If there are more than one, get the first non-Gregorian calendar
+                            Calendar nonGregorianCalendar = null;
+                            if (nonGregorianCalendars.Count > 0)
+                            {
+                                nonGregorianCalendar = nonGregorianCalendars[0];
+                            }
+
+                            // Reset the culture's calendar
+                            culture.DateTimeFormat.Calendar = nonGregorianCalendar;
+                        }
+                    }
+
                     var era = culture.DateTimeFormat.Calendar.GetEra(date.AdjustedDateTime);
                     var digits = token.Length;
-                    if (digits < 3)
+                    if (digits == 1)
+                    {
+                        string eraName;
+
+                        if (culture.Name.StartsWith("ja"))
+                        {
+                            eraName = GetJapaneseEraEnglishAbbreviation(culture, era);
+                        }
+                        else
+                        {
+                            eraName = culture.DateTimeFormat.GetAbbreviatedEraName(era);
+                        }
+
+                        result.Append(eraName);
+                    }
+                    else if (digits < 3)
                     {
                         result.Append(culture.DateTimeFormat.GetAbbreviatedEraName(era));
                     }
@@ -251,6 +362,11 @@ namespace ExcelNumberFormat
                     {
                         result.Append(culture.DateTimeFormat.GetEraName(era));
                     }
+                }
+                else if (token.StartsWith("e", StringComparison.OrdinalIgnoreCase))
+                {
+                    int year = culture.DateTimeFormat.Calendar.GetYear(date.AdjustedDateTime);
+                    result.Append(year);
                 }
                 else if (string.Compare(token, "am/pm", StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -294,11 +410,41 @@ namespace ExcelNumberFormat
                 }
                 else
                 {
-                    FormatLiteral(token, result);
+                    bool isNextTokenG = false;
+                    try
+                    {
+                        int tokenIndex = tokens.IndexOf(token);
+                        string gToken = tokens[tokenIndex + 1];
+                        if (gToken.Equals("g", StringComparison.OrdinalIgnoreCase))
+                        {
+                            isNextTokenG = true;
+                        }
+                    }
+                    catch (Exception)
+                    {
+
+                    }
+                    if (!isNextTokenG)
+                    {
+                        FormatLiteral(token, result);
+                    }
                 }
             }
 
             return result.ToString();
+        }
+
+        private static string GetJapaneseEraEnglishAbbreviation(CultureInfo culture, int era)
+        {
+            for (char c = 'A'; c <= 'Z'; c++)
+            {
+                int thisEra = culture.DateTimeFormat.GetEra(c.ToString());
+                if (thisEra > 0 && thisEra == era)
+                {
+                    return c.ToString();
+                }
+            }
+            return string.Empty;
         }
 
         private static bool LookAheadDatePart(List<string> tokens, int fromIndex, string startsWith)

--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -246,70 +246,71 @@ namespace ExcelNumberFormat
                     {
                         if (culture == CultureInfo.InvariantCulture)
                         {
+                            int tokenIndex = tokens.IndexOf(token);
+                            string localeId = string.Empty;
                             try
                             {
-                                int tokenIndex = tokens.IndexOf(token);
-                                string localeId = tokens[tokenIndex - 1];
-                                if (!string.IsNullOrEmpty(localeId))
-                                {
-                                    localeId = localeId.Trim('\"');
-                                }
-                                if (int.TryParse(localeId, NumberStyles.HexNumber, culture, out int lcid))
-                                {
-                                    // .NET Standard 1.0 does not support creating CultureInfo from a LCID,
-                                    // so we find one from a custom dictionary. Here we support only:
-                                    //  Japanese, Chinese Traditional (Taiwan)
-                                    Dictionary<int, string> dictCultureInfo = new Dictionary<int, string>()
-                                    {
-                                        { 1041, "ja-JP" },
-                                        { 1028, "zh-TW" }
-                                    };
-                                    if (dictCultureInfo.TryGetValue(lcid, out string locale))
-                                    {
-                                        culture = new CultureInfo(locale);
-                                        if (culture.Name.StartsWith("ja", StringComparison.OrdinalIgnoreCase))
-                                        {
-                                            Calendar japaneseCalendar = null;
-                                            foreach (var calendar in culture.OptionalCalendars)
-                                            {
-                                                if (calendar.GetType() == CultureInfo.InvariantCulture.Calendar.GetType())
-                                                {
-                                                    continue;
-                                                }
-                                                japaneseCalendar = calendar;
-                                                break;
-                                            }
-                                            if (japaneseCalendar != null)
-                                            {
-                                                culture.DateTimeFormat.Calendar = japaneseCalendar;
-                                            }
-                                            //era = culture.DateTimeFormat.Calendar.GetEra(date.AdjustedDateTime);
-                                            //eraName = GetJapaneseEraEnglishAbbreviation(culture, era);
-                                        }
-                                        else if (string.Equals(culture.Name, "zh-TW", StringComparison.OrdinalIgnoreCase))
-                                        {
-                                            Calendar taiwanCalendar = null;
-                                            foreach (var calendar in culture.OptionalCalendars)
-                                            {
-                                                if (calendar.GetType() == CultureInfo.InvariantCulture.Calendar.GetType())
-                                                {
-                                                    continue;
-                                                }
-                                                taiwanCalendar = calendar;
-                                                break;
-                                            }
-                                            if (taiwanCalendar != null)
-                                            {
-                                                culture.DateTimeFormat.Calendar = taiwanCalendar;
-                                            }
-                                            //eraName = culture.DateTimeFormat.GetAbbreviatedEraName(era);
-                                        }
-                                    }
-                                }
+                                localeId = tokens[tokenIndex - 1];
                             }
                             catch (Exception)
                             {
 
+                            }
+                            if (!string.IsNullOrEmpty(localeId))
+                            {
+                                localeId = localeId.Trim('\"');
+                            }
+                            if (int.TryParse(localeId, NumberStyles.HexNumber, culture, out int lcid))
+                            {
+                                // .NET Standard 1.0 does not support creating CultureInfo from a LCID,
+                                // so we find one from a custom dictionary. Here we support only:
+                                //  Japanese, Chinese Traditional (Taiwan)
+                                var dictCultureInfo = new Dictionary<int, string>()
+                                {
+                                    { 1041, "ja-JP" },
+                                    { 1028, "zh-TW" }
+                                };
+                                if (dictCultureInfo.TryGetValue(lcid, out string locale))
+                                {
+                                    culture = new CultureInfo(locale);
+                                    if (culture.Name.StartsWith("ja", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        Calendar japaneseCalendar = null;
+                                        foreach (var calendar in culture.OptionalCalendars)
+                                        {
+                                            if (calendar.GetType() == CultureInfo.InvariantCulture.Calendar.GetType())
+                                            {
+                                                continue;
+                                            }
+                                            japaneseCalendar = calendar;
+                                            break;
+                                        }
+                                        if (japaneseCalendar != null)
+                                        {
+                                            culture.DateTimeFormat.Calendar = japaneseCalendar;
+                                        }
+                                        //era = culture.DateTimeFormat.Calendar.GetEra(date.AdjustedDateTime);
+                                        //eraName = GetJapaneseEraEnglishAbbreviation(culture, era);
+                                    }
+                                    else if (string.Equals(culture.Name, "zh-TW", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        Calendar taiwanCalendar = null;
+                                        foreach (var calendar in culture.OptionalCalendars)
+                                        {
+                                            if (calendar.GetType() == CultureInfo.InvariantCulture.Calendar.GetType())
+                                            {
+                                                continue;
+                                            }
+                                            taiwanCalendar = calendar;
+                                            break;
+                                        }
+                                        if (taiwanCalendar != null)
+                                        {
+                                            culture.DateTimeFormat.Calendar = taiwanCalendar;
+                                        }
+                                        //eraName = culture.DateTimeFormat.GetAbbreviatedEraName(era);
+                                    }
+                                }
                             }
                         }
                         else
@@ -411,18 +412,20 @@ namespace ExcelNumberFormat
                 else
                 {
                     bool isNextTokenG = false;
+                    int tokenIndex = tokens.IndexOf(token);
+                    string gToken = string.Empty;
                     try
                     {
-                        int tokenIndex = tokens.IndexOf(token);
-                        string gToken = tokens[tokenIndex + 1];
-                        if (gToken.Equals("g", StringComparison.OrdinalIgnoreCase))
-                        {
-                            isNextTokenG = true;
-                        }
+                        gToken = tokens[tokenIndex + 1];
                     }
                     catch (Exception)
                     {
 
+                    }
+
+                    if (gToken.Equals("g", StringComparison.OrdinalIgnoreCase))
+                    {
+                        isNextTokenG = true;
                     }
                     if (!isNextTokenG)
                     {

--- a/src/ExcelNumberFormat/Parser.cs
+++ b/src/ExcelNumberFormat/Parser.cs
@@ -74,6 +74,8 @@ namespace ExcelNumberFormat
                         color = parseColor;
                     else if (TryParseCurrencySymbol(expression, out var parseCurrencySymbol))
                         tokens.Add("\"" + parseCurrencySymbol + "\"");
+                    else if (TryParseCultureSymbol(expression, out var parseCultureSymbol))
+                        tokens.Add("\"" + parseCultureSymbol + "\"");
                 }
                 else
                 {
@@ -263,7 +265,9 @@ namespace ExcelNumberFormat
                 reader.ReadOneOrMore('s') ||
                 reader.ReadOneOrMore('S') ||
                 reader.ReadOneOrMore('g') ||
-                reader.ReadOneOrMore('G'))
+                reader.ReadOneOrMore('G') ||
+                reader.ReadOneOrMore('e')
+                )
             {
                 syntaxError = false;
                 var length = reader.Position - offset;
@@ -386,13 +390,38 @@ namespace ExcelNumberFormat
                 return false;
             }
 
-
             if (token.Contains("-"))
                 currencySymbol = token.Substring(1, token.IndexOf('-') - 1);
             else
                 currencySymbol = token.Substring(1);
 
-            return true;
+            if (string.IsNullOrEmpty(currencySymbol))
+                return false;
+            else
+                return true;
+        }
+
+        private static bool TryParseCultureSymbol(string token, out string cultureSymbol)
+        {
+            if (string.IsNullOrEmpty(token)
+                || !token.StartsWith("$"))
+            {
+                cultureSymbol = null;
+                return false;
+            }
+
+            int dashIndex = token.IndexOf('-');
+            if (dashIndex == 1)
+            {
+                // "-411" -> "411" (hex)
+                cultureSymbol = token.Substring(dashIndex + 1);
+            }
+            else
+            {
+                cultureSymbol = string.Empty;
+            }
+
+            return !string.IsNullOrEmpty(cultureSymbol);
         }
     }
 }

--- a/src/ExcelNumberFormat/Token.cs
+++ b/src/ExcelNumberFormat/Token.cs
@@ -69,6 +69,7 @@ namespace ExcelNumberFormat
                 token.StartsWith("d", StringComparison.OrdinalIgnoreCase) ||
                 token.StartsWith("s", StringComparison.OrdinalIgnoreCase) ||
                 token.StartsWith("h", StringComparison.OrdinalIgnoreCase) ||
+                //token.StartsWith("e", StringComparison.OrdinalIgnoreCase) ||
                 (token.StartsWith("g", StringComparison.OrdinalIgnoreCase) && !IsGeneral(token)) ||
                 string.Compare(token, "am/pm", StringComparison.OrdinalIgnoreCase) == 0 ||
                 string.Compare(token, "a/p", StringComparison.OrdinalIgnoreCase) == 0 ||

--- a/test/ExcelNumberFormat.Tests/Class1.cs
+++ b/test/ExcelNumberFormat.Tests/Class1.cs
@@ -985,5 +985,14 @@ namespace ExcelNumberFormat.Tests
             Test(1234.56, "[$€-1809]# ##0.00", "€1 234.56");
             Test(1234.56, "#,##0.00 [$EUR]", "1,234.56 EUR");
         }
+
+        [TestMethod]
+        public void TestEra()
+        {
+            // Japan
+            Test(44200, @"[$-411]ge\.m\.d;@", "R3.1.4");
+            // Taiwan
+            Test(44200, @"[$-404]ge\.m\.d;@", "民國110.1.4");
+        }
     }
 }


### PR DESCRIPTION
This PR allows locales (Japanese, Chinese Traditional (Taiwan)) to show dates with era correctly by recognizing the era format code.